### PR TITLE
need to include types supported by DB::Any

### DIFF
--- a/src/jasper_helpers.cr
+++ b/src/jasper_helpers.cr
@@ -1,7 +1,7 @@
 require "./jasper_helpers/*"
 
 module JasperHelpers
-  alias OptionHash = Hash(Symbol, String | Symbol | Bool | Int32 | Float64 | Nil)
+  alias OptionHash = Hash(Symbol, Nil | String | Symbol | Bool | Int32 | Int64 | Float32 | Float64 | Time | Bytes)
 
   include Tags
   include Forms


### PR DESCRIPTION
This fixes an issue in Amber that doesn't compile when `Int64` data types is used. 

https://github.com/amberframework/amber/issues/260