### PR TITLE
fixes: labels for checkboxes aren't clickable

### DIFF
--- a/spec/jasper_helpers/forms_spec.cr
+++ b/spec/jasper_helpers/forms_spec.cr
@@ -122,22 +122,22 @@ describe JasperHelpers::Forms do
 
   describe "#check_box" do
     it "creates a check_box with yes/no" do
-      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed\" value=\"no\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"yes\"/>"
+      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed_default\" value=\"no\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"yes\"/>"
       check_box(:allowed, checked_value: "yes", unchecked_value: "no").should eq(expected)
     end
 
     it "creates a check_box with only value" do
-      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\"/>"
+      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed_default\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\"/>"
       check_box(:allowed).should eq(expected)
     end
 
     it "marks box as checked" do
-      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\" checked=\"checked\"/>"
+      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed_default\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\" checked=\"checked\"/>"
       check_box(:allowed, checked: true).should eq(expected)
     end
 
     it "marks box as not checked" do
-      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\"/>"
+      expected = "<input type=\"hidden\" name=\"allowed\" id=\"allowed_default\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\"/>"
       check_box(:allowed, checked: false).should eq(expected)
     end
   end

--- a/src/jasper_helpers/forms.cr
+++ b/src/jasper_helpers/forms.cr
@@ -131,7 +131,7 @@ module JasperHelpers::Forms
     end
 
     String.build do |str|
-      str << hidden_field(name, value: unchecked_value, id: "#{name}_default")
+      str << hidden_field(name, value: unchecked_value, id: "#{options_hash[:id]}_default")
       str << input_field(type: :checkbox, options: options_hash)
     end
   end

--- a/src/jasper_helpers/forms.cr
+++ b/src/jasper_helpers/forms.cr
@@ -131,7 +131,7 @@ module JasperHelpers::Forms
     end
 
     String.build do |str|
-      str << hidden_field(name, value: unchecked_value)
+      str << hidden_field(name, value: unchecked_value, id: "#{name}_default")
       str << input_field(type: :checkbox, options: options_hash)
     end
   end


### PR DESCRIPTION
This pattern is common and should produce a clickable label which increases the click surface of the checkbox:

```slang
    == check_box name: "allow", checked: object.allow
    == label :allow, "Allow things"
```

The current behavior incorrectly renders the hidden input with the same HTMTL id as the checkbox, which renders the label inoperable.