### PR TITLE
Fix checkbox label overlaping

### DIFF
--- a/spec/jasper_helpers/forms_spec.cr
+++ b/spec/jasper_helpers/forms_spec.cr
@@ -32,6 +32,13 @@ describe JasperHelpers::Forms do
     it "creates with string and options" do
       label(:name, "My Label", class: "label").should eq("<label for=\"name\" id=\"name_label\" class=\"label\">My Label</label>")
     end
+
+    it "creates with content" do
+      expected = "<label for=\"name\" id=\"name_label\"><input type=\"hidden\" name=\"allowed\" id=\"allowed_default\" value=\"0\"/><input type=\"checkbox\" name=\"allowed\" id=\"allowed\" value=\"1\"/>Name</label>"
+      label(:name) do
+        check_box(:allowed)
+      end.should eq(expected)
+    end
   end
 
   describe "#form" do

--- a/src/jasper_helpers/forms.cr
+++ b/src/jasper_helpers/forms.cr
@@ -19,6 +19,11 @@ module JasperHelpers::Forms
     label(name, content: (content ? content : name.to_s.capitalize), for: name, id: "#{Kit.css_safe(name)}_label")
   end
 
+  def label(name : String | Symbol)
+    content = "#{yield} #{name.to_s.capitalize}"
+    label(name, content: content, for: name, id: "#{Kit.css_safe(name)}_label")
+  end
+
   # form
   def form(method = :post, **options : Object, &block)
     options_hash = Kit.safe_hash(options, {:method => (method == :get ? :get : :post)})

--- a/src/jasper_helpers/forms.cr
+++ b/src/jasper_helpers/forms.cr
@@ -20,7 +20,7 @@ module JasperHelpers::Forms
   end
 
   def label(name : String | Symbol)
-    content = "#{yield} #{name.to_s.capitalize}"
+    content = "#{yield}#{name.to_s.capitalize}"
     label(name, content: content, for: name, id: "#{Kit.css_safe(name)}_label")
   end
 


### PR DESCRIPTION
Fixes #21 

Before:

```slim
div.checkbox
  == label(:published)
  == check_box(:published, checked: post.published.to_s == "1")
```

![screenshot_20180101_125738](https://user-images.githubusercontent.com/3067335/34469741-5a2c4c3e-eef3-11e7-9384-8d53780f66e6.png)

After: (this PR)

```slim
div.checkbox
  == label(:published) do
    == check_box(:published, checked: post.published.to_s == "1")
```

![screenshot_20180101_130316](https://user-images.githubusercontent.com/3067335/34469803-24564492-eef4-11e7-954f-272f1f6b64bb.png)
