### PR TITLE
select_field: selected value now also allows Array(Int32), Array(String | Int32)

### DIFF
--- a/spec/jasper_helpers/forms_spec.cr
+++ b/spec/jasper_helpers/forms_spec.cr
@@ -120,14 +120,29 @@ describe JasperHelpers::Forms do
       select_field(:age, {"1": "A", "2": "B"}, id: "age_of_thing").should eq(expected)
     end
 
-    it "creates a select_field with B selected" do
+    it "creates a select_field with B selected (String scalar)" do
       expected = "<select name=\"age\"><option value=\"1\">A</option><option value=\"2\" selected=\"selected\">B</option></select>"
       select_field(:age, {"1": "A", "2": "B"}, selected: "2").should eq(expected)
     end
 
-    it "creates a select_field with B and C selected" do
+    it "creates a select_field with B selected (Int32 scalar)" do
+      expected = "<select name=\"age\"><option value=\"1\">A</option><option value=\"2\" selected=\"selected\">B</option></select>"
+      select_field(:age, {"1": "A", "2": "B"}, selected: 2).should eq(expected)
+    end
+
+    it "creates a select_field with B and C selected (String array)" do
       expected = "<select name=\"age\"><option value=\"1\">A</option><option value=\"2\" selected=\"selected\">B</option><option value=\"3\" selected=\"selected\">C</option></select>"
       select_field(:age, {"1": "A", "2": "B", "3": "C"}, selected: ["2", "3"]).should eq(expected)
+    end
+
+    it "creates a select_field with B and C selected (Int32 array)" do
+      expected = "<select name=\"age\"><option value=\"1\">A</option><option value=\"2\" selected=\"selected\">B</option><option value=\"3\" selected=\"selected\">C</option></select>"
+      select_field(:age, {"1": "A", "2": "B", "3": "C"}, selected: [2, 3]).should eq(expected)
+    end
+
+    it "creates a select_field with B and C selected (Int32 | String array)" do
+      expected = "<select name=\"age\"><option value=\"1\">A</option><option value=\"2\" selected=\"selected\">B</option><option value=\"3\" selected=\"selected\">C</option></select>"
+      select_field(:age, {"1": "A", "2": "B", "3": "C"}, selected: [2, "3"]).should eq(expected)
     end
 
     it "creates a select_field with single dimension array" do

--- a/src/jasper_helpers.cr
+++ b/src/jasper_helpers.cr
@@ -1,7 +1,7 @@
 require "./jasper_helpers/*"
 
 module JasperHelpers
-  alias OptionHash = Hash(Symbol, Nil | String | Symbol | Bool | Int8 | Int16 | Int32 | Int64 | Float32 | Float64 | Time | Bytes | Array(String))
+  alias OptionHash = Hash(Symbol, Nil | String | Symbol | Bool | Int8 | Int16 | Int32 | Int64 | Float32 | Float64 | Time | Bytes | Array(String) | Array(Int32) | Array(String | Int32))
 
   include Tags
   include Forms


### PR DESCRIPTION
Implemented suggestion from @elorest to allow Int32s in the selected value array. (Didn't occur to me because my app uses UUIDs.)
https://github.com/amberframework/jasper-helpers/pull/31#issuecomment-437061884